### PR TITLE
AB#135356: Move over RQuest polling functionality from old HutchManager

### DIFF
--- a/app/RquestBridge/Config/RQuestOptions.cs
+++ b/app/RquestBridge/Config/RQuestOptions.cs
@@ -1,4 +1,4 @@
-namespace RquestBridge.Models;
+namespace RquestBridge.Config;
 
 public class RQuestOptions
 {

--- a/app/RquestBridge/Config/RQuestOptions.cs
+++ b/app/RquestBridge/Config/RQuestOptions.cs
@@ -6,6 +6,6 @@ public class RQuestOptions
 
   public string Host { get; set; } = string.Empty;
   
-  public string ResourceId { get; set; } = string.Empty;
+  public string CollectionId { get; set; } = string.Empty;
   
 }

--- a/app/RquestBridge/Config/RQuestOptions.cs
+++ b/app/RquestBridge/Config/RQuestOptions.cs
@@ -2,7 +2,6 @@ namespace RquestBridge.Config;
 
 public class RQuestOptions
 {
-  public int Id { get; set; }
 
   public string Host { get; set; } = string.Empty;
   

--- a/app/RquestBridge/Config/RQuestPollingOptions.cs
+++ b/app/RquestBridge/Config/RQuestPollingOptions.cs
@@ -1,0 +1,10 @@
+namespace RquestBridge.Config;
+
+public class RQuestPollingOptions
+{
+  /// <summary>
+  /// Polling interval in seconds
+  /// for fetching jobs from Activity Sources
+  /// </summary>
+  public int PollingInterval { get; set; } = 5; 
+}

--- a/app/RquestBridge/Config/RabbitJobQueueOptions.cs
+++ b/app/RquestBridge/Config/RabbitJobQueueOptions.cs
@@ -1,0 +1,11 @@
+using RabbitMQ.Client;
+
+namespace RquestBridge.Config;
+
+public class RabbitJobQueueOptions
+{
+  public string HostName { get; set; } = "";
+  public int Port { get; set; } = AmqpTcpEndpoint.UseDefaultPort;
+  public string UserName { get; set; } = ConnectionFactory.DefaultUser;
+  public string Password { get; set; } = ConnectionFactory.DefaultPass;
+}

--- a/app/RquestBridge/Config/RquestTaskApiOptions.cs
+++ b/app/RquestBridge/Config/RquestTaskApiOptions.cs
@@ -1,0 +1,45 @@
+﻿namespace RquestBridge.Config
+{
+    /// <summary>
+    /// Options for the RQuest Task Api
+    /// </summary>
+    public class RQuestTaskApiOptions
+    {
+        /// <summary>
+        /// <para>The Base Path of the Task API endpoints, which will be added to an RQuest Activity Source's Host URI</para>
+        ///
+        /// <para>
+        /// e.g.</para>
+        /// <para>Host URI configured as `https://my-rquest.com:12345`</para>
+        /// <para>EndpointBase of `bcos-rest/task`</para>
+        ///
+        /// <para>Actual requests will go to `https://my-rquest.com:12345/bcos-rest/task/&lt;endpoint&gt;`</para>
+        /// </summary>
+        public string EndpointBase { get; set; } = "bcrquest/api/task";
+
+        /// <summary>
+        /// Queue Status Endpoint
+        /// </summary>
+        public string QueueStatusEndpoint { get; set; } = "queue";
+
+        /// <summary>
+        /// Fetch Query Endpoint
+        /// </summary>
+        public string FetchQueryEndpoint { get; set; } = "nextjob";
+
+        /// <summary>
+        /// Submit Result Endpoint
+        /// </summary>
+        public string SubmitResultEndpoint { get; set; } = "result";
+        
+        /// <summary>
+        /// Username for the RQuest API. To be used in the Basic Auth header.
+        /// </summary>
+        public string Username { get; set; } = string.Empty;
+        
+        /// <summary>
+        /// Password for the RQuest API. To be used in the Basic Auth header.
+        /// </summary>
+        public string Password { get; set; } = string.Empty;
+    }
+}

--- a/app/RquestBridge/Config/RquestTaskApiOptions.cs
+++ b/app/RquestBridge/Config/RquestTaskApiOptions.cs
@@ -15,7 +15,7 @@
         ///
         /// <para>Actual requests will go to `https://my-rquest.com:12345/bcos-rest/task/&lt;endpoint&gt;`</para>
         /// </summary>
-        public string EndpointBase { get; set; } = "bcrquest/api/task";
+        public string EndpointBase { get; set; } = "bcos-rest/api/task";
 
         /// <summary>
         /// Queue Status Endpoint

--- a/app/RquestBridge/Constants/RQuestJobTypeSuffixes.cs
+++ b/app/RquestBridge/Constants/RQuestJobTypeSuffixes.cs
@@ -1,0 +1,11 @@
+﻿namespace RquestBridge.Constants;
+
+public static class RQuestJobTypeSuffixes
+{
+  public const string AvailabilityQuery = ".a";
+  public const string AnalyticsGenePhewas = ".b";
+  public const string Distribution = ".b";
+  public const string AnalyticsGwas = ".c";
+  public const string AnalyticsGwasQuantitiveTrait = ".c";
+  public const string AnalyticsBurdenTest = ".c";
+}

--- a/app/RquestBridge/Constants/RQuestJobTypes.cs
+++ b/app/RquestBridge/Constants/RQuestJobTypes.cs
@@ -1,0 +1,7 @@
+namespace RquestBridge.Constants;
+
+public class RQuestJobTypes
+{
+  public const string AvailabilityQuery = "AvailabilityQuery";
+  public const string DistributionQuery = "DistributionQuery";
+}

--- a/app/RquestBridge/Dto/RQuestAvailabilityQuery.cs
+++ b/app/RquestBridge/Dto/RQuestAvailabilityQuery.cs
@@ -1,0 +1,84 @@
+using System.Text.Json.Serialization;
+
+namespace RquestBridge.Dto;
+
+public class AvailabilityQuery
+{
+  [JsonPropertyName("owner")]
+  public string Owner { get; set; } = string.Empty;
+
+  [JsonPropertyName("cohort")] 
+  public Cohort Cohort { get; set; } = new();
+  
+  /// <summary>
+  /// The collection ID to run the query against.
+  /// </summary>
+  [JsonPropertyName("collection")]
+  public string Collection { get; set; } = String.Empty;
+  
+  [JsonPropertyName("protocol_version")]
+  public string ProtocolVersion { get; set; } = String.Empty;
+  
+  [JsonPropertyName("char_salt")]
+  public string CharSalt { get; set; } = String.Empty;
+  
+  [JsonPropertyName("uuid")]
+  public string Uuid { get; set; } = String.Empty;
+}
+
+public class Cohort
+{
+  [JsonPropertyName("groups_oper")]
+  public string Combinator { get; set; } = string.Empty;
+
+  [JsonPropertyName("groups")]
+  public List<Group> Groups { get; set; } = new ();
+}
+
+public class Group
+{
+  [JsonPropertyName("rules_oper")]
+  public string Combinator { get; set; } = string.Empty;
+
+  [JsonPropertyName("rules")]
+  public List<Rule> Rules { get; set; } = new ();
+}
+
+public class Rule
+{
+  [JsonPropertyName("type")]
+  public string Type { get; set; } = string.Empty;
+
+  [JsonPropertyName("varname")]
+  public string VariableName { get; set; } = string.Empty;
+
+  /// <summary>
+  /// Note that this isn't really an operand on the value
+  /// it's pure inclusion or exclusion criteria: `=` or `!=`
+  /// </summary>
+  [JsonPropertyName("oper")]
+  public string Operand { get; set; } = string.Empty;
+
+  [JsonPropertyName("value")]
+  public string Value { get; set; } = string.Empty;
+        
+  [JsonPropertyName("time")]
+  public string Time { get; set; } = string.Empty;
+
+  [JsonPropertyName("ext")]
+  public string ExternalAttribute { get; set; } = string.Empty;
+
+  /// <summary>
+  /// Reserved for Future Use with some types (e.g. NUMERIC)
+  /// 
+  /// </summary>
+  [JsonPropertyName("unit")]
+  public string Unit { get; set; } = string.Empty;
+
+  /// <summary>
+  /// TEXT type only; the string to be uased for matching
+  /// in a SQL `LIKE` expression (not, confusingly, a RegEx)
+  /// </summary>
+  [JsonPropertyName("regex")]
+  public string RegEx { get; set; } = string.Empty;
+}

--- a/app/RquestBridge/Dto/RQuestDistributionQuery.cs
+++ b/app/RquestBridge/Dto/RQuestDistributionQuery.cs
@@ -1,0 +1,39 @@
+using System.Text.Json.Serialization;
+
+namespace RquestBridge.Dto;
+
+public class DistributionQuery
+{
+  /// <summary>
+  /// The user that creates the task.
+  /// </summary>
+  [JsonPropertyName("owner")]
+  public string Owner { get; set; } = String.Empty;
+
+  /// <summary>
+  /// The code for the type of distribution query.
+  /// Possible values: "GENERIC", "DEMOGRAPHICS" or "ICD-MAN"
+  /// </summary>
+  [JsonPropertyName("code")]
+  public string Code  { get; set; } = String.Empty;
+
+  /// <summary>
+  /// The type of analysis to be carried out.
+  /// Possible values: "DISTRIBUTION"
+  /// </summary>
+  [JsonPropertyName("analysis")]
+  public string Analysis { get; set; } = "DISTRIBUTION";
+
+  /// <summary>
+  /// UUid sets JobId using "uuid" as the property name
+  /// This is due to the incoming RQuest query using "uuid" as the key name.
+  /// </summary>
+  [JsonPropertyName("uuid")]
+  public string Uuid { get; set; } = String.Empty;
+
+    /// <summary>
+  /// The collection ID to run the query against.
+  /// </summary>
+  [JsonPropertyName("collection")]
+  public string Collection { get; set; } = String.Empty;
+}

--- a/app/RquestBridge/Dto/RQuestJob.cs
+++ b/app/RquestBridge/Dto/RQuestJob.cs
@@ -21,12 +21,6 @@ public class RQuestJob
   public string JobId { get; set; } = string.Empty;
   
   /// <summary>
-  /// The ID of the activity source.
-  /// </summary>
-  [JsonPropertyName("rquest_id")] 
-  public int RQuestJobId { get; set; }
-  
-  /// <summary>
   /// The properties of the job.
   /// </summary>
   [JsonPropertyName("payload")]

--- a/app/RquestBridge/Dto/RQuestJob.cs
+++ b/app/RquestBridge/Dto/RQuestJob.cs
@@ -1,0 +1,34 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace RquestBridge.Dto;
+
+/// <summary>
+/// Represents an activity as its type and properties as its payload.
+/// </summary>
+public class RQuestJob
+{
+  /// <summary>
+  /// The type of job. e.g. Availability Query.
+  /// </summary>
+  [JsonPropertyName("type")]
+  public string Type { get; set; } = string.Empty;
+  
+  /// <summary>
+  /// UUID identifying the job.
+  /// </summary>
+  [JsonPropertyName("job_id")]
+  public string JobId { get; set; } = string.Empty;
+  
+  /// <summary>
+  /// The ID of the activity source.
+  /// </summary>
+  [JsonPropertyName("rquest_id")] 
+  public int RQuestJobId { get; set; }
+  
+  /// <summary>
+  /// The properties of the job.
+  /// </summary>
+  [JsonPropertyName("payload")]
+  public JsonElement Payload { get; set; }
+}

--- a/app/RquestBridge/Models/RQuestOptions.cs
+++ b/app/RquestBridge/Models/RQuestOptions.cs
@@ -1,0 +1,11 @@
+namespace RquestBridge.Models;
+
+public class RQuestOptions
+{
+  public int Id { get; set; }
+
+  public string Host { get; set; } = string.Empty;
+  
+  public string ResourceId { get; set; } = string.Empty;
+  
+}

--- a/app/RquestBridge/Program.cs
+++ b/app/RquestBridge/Program.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using RquestBridge.Config;
-using RquestBridge.Models;
 using RquestBridge.Services;
 using RquestBridge.Services.Hosted;
 

--- a/app/RquestBridge/Program.cs
+++ b/app/RquestBridge/Program.cs
@@ -1,9 +1,26 @@
-﻿namespace RquestBridge;
+﻿using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using RquestBridge.Config;
+using RquestBridge.Models;
+using RquestBridge.Services;
+using RquestBridge.Services.Hosted;
+
+namespace RquestBridge;
 
 class Program
 {
-    static void Main(string[] args)
-    {
-        Console.WriteLine("Hello, World!");
-    }
-}
+  public static void Main(string[] args)
+  {
+    IHost host = Host.CreateDefaultBuilder(args)
+      .ConfigureServices((hostContext, services) =>
+      {
+        services.AddHttpClient<RQuestTaskApiClient>();
+        services.AddScoped<RQuestAvailabilityPollingService>();
+        services.AddHostedService<RQuestPollingHostedService>();
+        services.AddTransient<RabbitJobQueueService>();
+        services.AddOptions<RQuestOptions>().Bind(hostContext.Configuration.GetSection("RQuest"));
+        services.AddOptions<RQuestTaskApiOptions>().Bind(hostContext.Configuration.GetSection("Credentials"));
+      })
+      .Build();
+    host.Run();
+  }}

--- a/app/RquestBridge/Properties/launchSettings.json
+++ b/app/RquestBridge/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "RquestBridge": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/app/RquestBridge/RquestBridge.csproj
+++ b/app/RquestBridge/RquestBridge.csproj
@@ -5,6 +5,20 @@
         <TargetFramework>net7.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <UserSecretsId>8f26d3a3-9450-4cfd-8dcb-0b34fd950557</UserSecretsId>
     </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Flurl" Version="3.0.7" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+      <PackageReference Include="RabbitMQ.Client" Version="6.6.0" />
+      <Content Include="appsettings.json">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </Content>
+      <Content Include="appsettings.Development.json">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </Content>
+    </ItemGroup>
 
 </Project>

--- a/app/RquestBridge/Services/Hosted/RQuestPollingHostedService.cs
+++ b/app/RquestBridge/Services/Hosted/RQuestPollingHostedService.cs
@@ -3,8 +3,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using RquestBridge.Config;
-using RquestBridge.Models;
-
 namespace RquestBridge.Services.Hosted;
 
 public class RQuestPollingHostedService : BackgroundService

--- a/app/RquestBridge/Services/Hosted/RQuestPollingHostedService.cs
+++ b/app/RquestBridge/Services/Hosted/RQuestPollingHostedService.cs
@@ -1,0 +1,69 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using RquestBridge.Config;
+using RquestBridge.Models;
+
+namespace RquestBridge.Services.Hosted;
+
+public class RQuestPollingHostedService : BackgroundService
+{
+  private readonly ILogger<RQuestPollingHostedService> _logger;
+  private readonly IServiceProvider _serviceProvider;
+  private readonly RQuestPollingOptions _config;
+  private readonly RQuestOptions _rQuestOptions;
+  private int _executionCount;
+
+  public RQuestPollingHostedService(
+    ILogger<RQuestPollingHostedService> logger,
+    IServiceProvider serviceProvider,
+    IOptions<RQuestPollingOptions> config, 
+    IOptions<RQuestOptions> rQuestOptions)
+  {
+    _logger = logger;
+    _serviceProvider = serviceProvider;
+    _rQuestOptions = rQuestOptions.Value;
+    _config = config.Value;
+  }
+
+  protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+  {
+    _logger.LogInformation("RQuest Polling started");
+
+    if (_config.PollingInterval < 0) return;
+
+    while (!stoppingToken.IsCancellationRequested)
+    {
+      var executionTask = TriggerActivitySourcePolling();
+
+      await Task.Delay(TimeSpan.FromSeconds(_config.PollingInterval), stoppingToken);
+    }
+  }
+
+  private async Task TriggerActivitySourcePolling()
+  {
+    var count = Interlocked.Increment(ref _executionCount);
+
+    _logger.LogDebug(
+      "{Service} is working. Count: {Count}", nameof(RQuestAvailabilityPollingService), count);
+
+    using var executionScope = _serviceProvider.CreateScope();
+
+    // TODO use another worker service with DI instead of Service Locator? 
+
+    var rQuestPoller = executionScope.ServiceProvider.GetRequiredService<RQuestAvailabilityPollingService>();
+
+    List<Task> pollTasks = new();
+
+    pollTasks.Add(rQuestPoller.Poll(_rQuestOptions));
+    await Task.WhenAll(pollTasks);
+  }
+
+  public override async Task StopAsync(CancellationToken stoppingToken)
+  {
+    _logger.LogInformation("Activity Source Polling stopping");
+
+    await base.StopAsync(stoppingToken);
+  }
+}

--- a/app/RquestBridge/Services/RQuestAvailabilityPollingService.cs
+++ b/app/RquestBridge/Services/RQuestAvailabilityPollingService.cs
@@ -60,7 +60,6 @@ public class RQuestAvailabilityPollingService
   {
     var job = new RQuestJob()
     {
-      RQuestJobId = rQuest.Id,
       Payload = JsonSerializer.SerializeToElement(jobPayload),
       Type = RQuestJobTypes.AvailabilityQuery,
       JobId = jobPayload.Uuid

--- a/app/RquestBridge/Services/RQuestAvailabilityPollingService.cs
+++ b/app/RquestBridge/Services/RQuestAvailabilityPollingService.cs
@@ -1,0 +1,76 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using RquestBridge.Constants;
+using RquestBridge.Dto;
+using RquestBridge.Models;
+
+namespace RquestBridge.Services;
+
+public class RQuestAvailabilityPollingService
+{
+  private readonly RQuestTaskApiClient _taskApi;
+  private readonly ILogger<RQuestAvailabilityPollingService> _logger;
+  private readonly RabbitJobQueueService _jobQueue;
+
+  public RQuestAvailabilityPollingService(
+    RQuestTaskApiClient taskApi,
+    ILogger<RQuestAvailabilityPollingService> logger,
+    RabbitJobQueueService jobQueue)
+  {
+    _logger = logger;
+    _taskApi = taskApi;
+    _jobQueue = jobQueue;
+  }
+
+  public async Task Poll(RQuestOptions rQuest)
+  {
+    AvailabilityQuery? job = null;
+
+    do
+    {
+      try
+      {
+        job = await _taskApi.FetchQuery<AvailabilityQuery>(rQuest);
+        if (job is null)
+        {
+          _logger.LogInformation(
+            "No Queries on Collection: {ResourceId}",
+            rQuest.ResourceId);
+          return;
+        }
+
+        var packagedJob = PackageJob(job, rQuest);
+        SendToQueue(packagedJob, "jobs");
+      }
+      catch (Exception e)
+      {
+        if (job is null)
+        {
+          _logger.LogError(e, "Task fetching failed");
+        }
+        else
+        {
+          throw;
+        }
+      }
+    } while (job is null);
+  }
+
+  private RQuestJob PackageJob(AvailabilityQuery jobPayload, RQuestOptions rQuest)
+  {
+    var job = new RQuestJob()
+    {
+      RQuestJobId = rQuest.Id,
+      Payload = JsonSerializer.SerializeToElement(jobPayload),
+      Type = RQuestJobTypes.AvailabilityQuery,
+      JobId = jobPayload.Uuid
+    };
+    return job;
+  }
+
+  private void SendToQueue(RQuestJob jobPayload, string queueName)
+  {
+    _jobQueue.SendMessage(queueName, jobPayload);
+    _logger.LogInformation("Sent to Queue {Body}", JsonSerializer.Serialize(jobPayload));
+  }
+}

--- a/app/RquestBridge/Services/RQuestAvailabilityPollingService.cs
+++ b/app/RquestBridge/Services/RQuestAvailabilityPollingService.cs
@@ -34,8 +34,8 @@ public class RQuestAvailabilityPollingService
         if (job is null)
         {
           _logger.LogInformation(
-            "No Queries on Collection: {ResourceId}",
-            rQuest.ResourceId);
+            "No Queries on Collection: {CollectionId}",
+            rQuest.CollectionId);
           return;
         }
 

--- a/app/RquestBridge/Services/RQuestAvailabilityPollingService.cs
+++ b/app/RquestBridge/Services/RQuestAvailabilityPollingService.cs
@@ -2,7 +2,7 @@ using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using RquestBridge.Constants;
 using RquestBridge.Dto;
-using RquestBridge.Models;
+using RquestBridge.Config;
 
 namespace RquestBridge.Services;
 

--- a/app/RquestBridge/Services/RabbitJobQueueService.cs
+++ b/app/RquestBridge/Services/RabbitJobQueueService.cs
@@ -1,0 +1,78 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+using RabbitMQ.Client;
+using RquestBridge.Config;
+
+namespace RquestBridge.Services;
+
+public class RabbitJobQueueService
+{
+  private readonly IConnection _connection;
+  private readonly IModel _channel;
+  private readonly RabbitJobQueueOptions _options;
+
+
+  public RabbitJobQueueService(IOptions<RabbitJobQueueOptions> options)
+  {
+    _options = options.Value;
+    var connectionFactory = new ConnectionFactory()
+    {
+      HostName = _options.HostName,
+      Port = _options.Port,
+      UserName = _options.UserName,
+      Password = _options.Password
+    };
+    _connection = connectionFactory.CreateConnection();
+    _channel = _connection.CreateModel();
+  }
+
+  /// <summary>
+  /// Serialize an object and send it, serialised to JSON, as a message to the named queue
+  /// </summary>
+  /// <param name="queueName"></param>
+  /// <param name="message"></param>
+  /// <typeparam name="T">The CLR type of the message</typeparam>
+  public void SendMessage<T>(string queueName, T message) where T : class
+  {
+    _channel.QueueDeclare(queue: queueName,
+      durable: false,
+      exclusive: false,
+      autoDelete: false,
+      arguments: null);
+
+    var body = Encoding.UTF8.GetBytes(
+      JsonSerializer.Serialize(message));
+    _channel.BasicPublish(
+      exchange: "",
+      basicProperties: null,
+      routingKey: queueName,
+      body: body);
+  }
+
+  ~RabbitJobQueueService()
+  {
+    Dispose(false);
+  }
+
+  private void ReleaseUnmanagedResources()
+  {
+    // TODO release unmanaged resources here
+  }
+
+  private void Dispose(bool disposing)
+  {
+    ReleaseUnmanagedResources();
+    if (disposing)
+    {
+      _connection.Dispose();
+      _channel.Dispose();
+    }
+  }
+
+  public void Dispose()
+  {
+    Dispose(true);
+    GC.SuppressFinalize(this);
+  }
+}

--- a/app/RquestBridge/Services/RquestTaskApiClient.cs
+++ b/app/RquestBridge/Services/RquestTaskApiClient.cs
@@ -65,7 +65,7 @@ namespace RquestBridge.Services
         _apiOptions.EndpointBase,
         _apiOptions.FetchQueryEndpoint,
         // Currently this method only looks for "Availability Queries""
-        rQuestOptions.ResourceId + typeSuffix);
+        rQuestOptions.CollectionId + typeSuffix);
       var result = await _client.GetAsync(
         requestUri);
 
@@ -74,8 +74,8 @@ namespace RquestBridge.Services
         if (result.StatusCode == HttpStatusCode.NoContent)
         {
           _logger.LogInformation(
-            "No Query Jobs waiting for {ResourceId}",
-            rQuestOptions.ResourceId);
+            "No Query Jobs waiting for {CollectionId}",
+            rQuestOptions.CollectionId);
           return null;
         }
 
@@ -122,7 +122,7 @@ namespace RquestBridge.Services
         _apiOptions.EndpointBase,
         _apiOptions.SubmitResultEndpoint,
         jobId,
-        activitySource.ResourceId);
+        activitySource.CollectionId);
 
       var response = (await _client.PostAsync(
           requestUri, AsHttpJsonString(result)))

--- a/app/RquestBridge/Services/RquestTaskApiClient.cs
+++ b/app/RquestBridge/Services/RquestTaskApiClient.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.Logging;
 using RquestBridge.Config;
 using RquestBridge.Constants;
 using RquestBridge.Dto;
-using RquestBridge.Models;
 
 namespace RquestBridge.Services
 {

--- a/app/RquestBridge/Services/RquestTaskApiClient.cs
+++ b/app/RquestBridge/Services/RquestTaskApiClient.cs
@@ -1,0 +1,146 @@
+using Flurl;
+using Microsoft.Extensions.Options;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using RquestBridge.Config;
+using RquestBridge.Constants;
+using RquestBridge.Dto;
+using RquestBridge.Models;
+
+namespace RquestBridge.Services
+{
+  public class RQuestTaskApiClient
+  {
+    private readonly HttpClient _client;
+    private readonly ILogger<RQuestTaskApiClient> _logger;
+    private readonly RQuestTaskApiOptions _apiOptions;
+
+    public RQuestTaskApiClient(
+      HttpClient client,
+      ILogger<RQuestTaskApiClient> logger,
+      IOptions<RQuestTaskApiOptions> apiOptions)
+    {
+      _client = client;
+      _logger = logger;
+      _apiOptions = apiOptions.Value;
+
+      // TODO: credentials in future will be per Activity Source, so won't be set as default
+      string credentials = _apiOptions.Username + ":" + _apiOptions.Password;
+      var authString = Convert.ToBase64String(Encoding.UTF8.GetBytes(credentials));
+      _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", authString);
+    }
+
+    /// <summary>
+    /// Serialize a value to a JSON string, and provide HTTP StringContent
+    /// for it with a media type of "application/json"
+    /// </summary>
+    /// <param name="value"></param>
+    /// <returns>HTTP StringContent with the value serialized to JSON and a media type of "application/json"</returns>
+    [Obsolete]
+    private StringContent AsHttpJsonString<T>(T value)
+      => new StringContent(
+        JsonSerializer.Serialize(value),
+        Encoding.UTF8,
+        "application/json");
+
+    /// <summary>
+    /// Try and get a job for a collection
+    /// </summary>
+    /// <param name="rQuestOptions"> RQuestOptions</param>
+    /// <returns>A Task DTO containing a Query to run, or null if none are waiting</returns>
+    public async Task<T?> FetchQuery<T>(RQuestOptions rQuestOptions) where T: class, new()
+    {
+      var typeSuffix = new T() switch
+      {
+        AvailabilityQuery _ => RQuestJobTypeSuffixes.AvailabilityQuery,
+        DistributionQuery _ => RQuestJobTypeSuffixes.Distribution,
+        _ => string.Empty
+        
+      };
+      var requestUri = Url.Combine(
+        rQuestOptions.Host,
+        _apiOptions.EndpointBase,
+        _apiOptions.FetchQueryEndpoint,
+        // Currently this method only looks for "Availability Queries""
+        rQuestOptions.ResourceId + typeSuffix);
+      var result = await _client.GetAsync(
+        requestUri);
+
+      if (result.IsSuccessStatusCode)
+      {
+        if (result.StatusCode == HttpStatusCode.NoContent)
+        {
+          _logger.LogInformation(
+            "No Query Jobs waiting for {ResourceId}",
+            rQuestOptions.ResourceId);
+          return null;
+        }
+
+        try
+        {
+          var job = await result.Content.ReadFromJsonAsync<T>();
+          return job;
+        }
+        catch (JsonException e)
+        {
+          _logger.LogError(e, "Invalid Response Format from Fetch Query Endpoint");
+
+          var body = await result.Content.ReadAsStringAsync();
+          _logger.LogDebug("Invalid Response Body: {Body}", body);
+
+          throw;
+        }
+      }
+      else
+      {
+        _logger.LogError("Fetch Query Endpoint Request failed: {StatusCode}", result.StatusCode);
+        throw new ApplicationException($"Fetch Query Endpoint Request failed: {result.StatusCode}");
+      }
+    }
+    
+    /*
+    /// <summary>
+    /// Post to the Results endpoint, and handle the response correctly
+    /// </summary>
+    /// <param name="activitySourceId">activitySourceId ID</param>
+    /// <param name="jobId">Job ID</param>
+    /// <param name="result">Results with Count</param>
+    public async Task ResultsEndpointPost(int activitySourceId, string jobId, RquestQueryResult result)
+    {
+      var activitySource = await _db.ActivitySources
+        .FirstOrDefaultAsync(x => x.Id == activitySourceId);
+
+      if (activitySource is null)
+        throw new KeyNotFoundException(
+          $"No ActivitySource with ID: {activitySourceId}");
+
+      var requestUri = Url.Combine(
+        activitySource.Host,
+        _apiOptions.EndpointBase,
+        _apiOptions.SubmitResultEndpoint,
+        jobId,
+        activitySource.ResourceId);
+
+      var response = (await _client.PostAsync(
+          requestUri, AsHttpJsonString(result)))
+        .EnsureSuccessStatusCode();
+
+      var body = await response.Content.ReadAsStringAsync();
+
+      if (body != "Job saved" && !response.IsSuccessStatusCode)
+      {
+        const string message = "Unsuccessful Response from Submit Results Endpoint";
+        _logger.LogError(message);
+        _logger.LogDebug("Response Body: {Body}", body);
+
+        throw new ApplicationException(message);
+      }
+
+      return;
+    }*/
+  }
+}

--- a/app/RquestBridge/appsettings.Development.json
+++ b/app/RquestBridge/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+    "Logging": {
+        "LogLevel": {
+            "Default": "Debug",
+            "System": "Information",
+            "Microsoft": "Information"
+        }
+    }
+}

--- a/app/RquestBridge/appsettings.json
+++ b/app/RquestBridge/appsettings.json
@@ -1,0 +1,9 @@
+{
+    "Logging": {
+        "LogLevel": {
+            "Default": "Debug",
+            "System": "Information",
+            "Microsoft": "Information"
+        }
+    }
+}


### PR DESCRIPTION
<!--
     ⚠ Ensure the PR title starts with a reference to the primary Azure Boards work item it completes, in the form `AB#<id> My PR Title`.
     
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     PR Guidance:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡️ Optimization
- [ ] 📝 Documentation Update

## Description

Move over RquestPollingHostedService functionality from old HutchManager
Add API config for rquest calls

<!--
If there are any further (child or related) Azure Boards work items, reference them here in the form `AB#<id>`
-->


<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

## Added/updated tests?

- [ ] ✅ Yes
- [x] ❌ No, and this is why:
  - _please replace this line with details on why tests have not been included_
- [ ] ❓ I need help with writing tests

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://i.imgflip.com/50ti1y.png)
